### PR TITLE
Update boot to add default services to context in addition to the service container.

### DIFF
--- a/boot.go
+++ b/boot.go
@@ -120,10 +120,10 @@ func (bs *Bootstrapper) Boot() int {
 	_ = serviceContainer.Set("config", cfg)
 
 	// Add default services to context
-	ctx = process.HealthWithContext(ctx, health)
-	ctx = log.WithContext(ctx, logger)
-	ctx = service.WithContext(ctx, serviceContainer)
-	ctx = config.WithContext(ctx, cfg)
+	ctx = process.ContextWithHealth(ctx, health)
+	ctx = log.WithLogger(ctx, logger)
+	ctx = service.WithContainer(ctx, serviceContainer)
+	ctx = config.WithConfig(ctx, cfg)
 
 	// Run the context filter after we've added the services to the context in
 	// case the user wants to tweak those services.

--- a/boot_test.go
+++ b/boot_test.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/go-nacelle/config/v2"
+	"github.com/go-nacelle/log/v2"
+	"github.com/go-nacelle/process/v2"
 	"github.com/go-nacelle/service/v2"
 	"github.com/stretchr/testify/assert"
 )
@@ -37,6 +40,7 @@ func TestDefaultServices(t *testing.T) {
 	bootstrapper := NewBootstrapper(
 		"APP",
 		func(ctx context.Context, processes *ProcessContainerBuilder, services *ServiceContainer) error {
+
 			return service.Inject(ctx, services, serviceChecker)
 		},
 	)
@@ -45,6 +49,30 @@ func TestDefaultServices(t *testing.T) {
 	assert.NotNil(t, serviceChecker.Health)
 	assert.NotNil(t, serviceChecker.Logger)
 	assert.NotNil(t, serviceChecker.Services)
+}
+
+func TestDefaultServicesInContext(t *testing.T) {
+	bootstrapper := NewBootstrapper(
+		"APP",
+		func(ctx context.Context, processes *ProcessContainerBuilder, services *ServiceContainer) error {
+			assert.NotNil(t, process.HealthFromContext(ctx))
+			assert.NotEqual(t, log.NewNilLogger(), log.FromContext(ctx))
+			assert.NotNil(t, service.FromContext(ctx))
+			assert.NotNil(t, config.FromContext(ctx))
+
+			return nil
+		},
+		WithContextFilter(func(ctx context.Context) context.Context {
+			assert.NotNil(t, process.HealthFromContext(ctx))
+			assert.NotEqual(t, log.NewNilLogger(), log.FromContext(ctx))
+			assert.NotNil(t, service.FromContext(ctx))
+			assert.NotNil(t, config.FromContext(ctx))
+
+			return ctx
+		}),
+	)
+
+	assert.Equal(t, 0, bootstrapper.Boot())
 }
 
 func TestInitFuncError(t *testing.T) {


### PR DESCRIPTION
This updates the nacelle `Boot` method to add the default services to the context in addition to the service container.

I originally thought about pulling the context methods out of the service container instead of storing them separately, but I didn't want to add a dependency from every other package on the `service` package to support things like `config.LoadFromContext`.

There's also a chance here of someone setting a different value in the service container and it not being updated in the context (such as setting a different "health" service in the container but not having the context updated). I figured this could at least start a conversation about it and we could figure out a better solution if you have another idea!