### PR TITLE
Fix Bootstrapper not logging process errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Update dependency [go-nacelle/service@v2.0.1] -> [go-nacelle/service@v2.1.0]
+
+### Fixed
+
+- Fixed process errors not being logged when encountered in `Bootstrapper`.
+
 ## [v2.1.0] - 2023-04-29
 
 ### Changed
@@ -225,6 +233,7 @@
 [go-nacelle/service@v1.0.2]: https://github.com/go-nacelle/service/releases/tag/v1.0.2
 [go-nacelle/service@v2.0.0]: https://github.com/go-nacelle/service/releases/tag/v2.0.0
 [go-nacelle/service@v2.0.1]: https://github.com/go-nacelle/service/releases/tag/v2.0.1
+[go-nacelle/service@v2.1.0]: https://github.com/go-nacelle/service/releases/tag/v2.1.0
 [v1.0.0]: https://github.com/go-nacelle/nacelle/releases/tag/v1.0.0
 [v1.0.1]: https://github.com/go-nacelle/nacelle/compare/v1.0.0...v1.0.1
 [v1.0.2]: https://github.com/go-nacelle/nacelle/compare/v1.0.1...v1.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- Update dependency [go-nacelle/service@v2.0.1] -> [go-nacelle/service@v2.1.0]
+- Update dependency [go-nacelle/process@v2.0.1] -> [go-nacelle/process@v2.1.0]
 
 ### Fixed
 
@@ -229,11 +229,11 @@
 [go-nacelle/process@v1.1.0]: https://github.com/go-nacelle/process/releases/tag/v1.1.0
 [go-nacelle/process@v2.0.0]: https://github.com/go-nacelle/process/releases/tag/v2.0.0
 [go-nacelle/process@v2.0.1]: https://github.com/go-nacelle/process/releases/tag/v2.0.1
+[go-nacelle/process@v2.1.0]: https://github.com/go-nacelle/process/releases/tag/v2.1.0
 [go-nacelle/service@v1.0.0]: https://github.com/go-nacelle/service/releases/tag/v1.0.0
 [go-nacelle/service@v1.0.2]: https://github.com/go-nacelle/service/releases/tag/v1.0.2
 [go-nacelle/service@v2.0.0]: https://github.com/go-nacelle/service/releases/tag/v2.0.0
 [go-nacelle/service@v2.0.1]: https://github.com/go-nacelle/service/releases/tag/v2.0.1
-[go-nacelle/service@v2.1.0]: https://github.com/go-nacelle/service/releases/tag/v2.1.0
 [v1.0.0]: https://github.com/go-nacelle/nacelle/releases/tag/v1.0.0
 [v1.0.1]: https://github.com/go-nacelle/nacelle/compare/v1.0.0...v1.0.1
 [v1.0.2]: https://github.com/go-nacelle/nacelle/compare/v1.0.1...v1.0.2

--- a/boot.go
+++ b/boot.go
@@ -182,6 +182,9 @@ func (bs *Bootstrapper) Boot() int {
 	statusCode := 0
 	if !state.Wait(ctx) {
 		statusCode = 1
+		for _, err := range state.Errors() {
+			logger.Error("%s", err)
+		}
 	}
 
 	logger.Info("All processes have stopped")

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/derision-test/glock v1.0.0 // indirect
 	github.com/go-nacelle/config/v3 v3.0.0
 	github.com/go-nacelle/log/v2 v2.0.1
-	github.com/go-nacelle/process/v2 v2.0.1
+	github.com/go-nacelle/process/v2 v2.1.0
 	github.com/go-nacelle/service/v2 v2.0.1
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-zglob v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/go-nacelle/config/v3 v3.0.0 h1:YseTUtwKC21rgWNdBh+f0A5ANnh7kSMqGkB2JH
 github.com/go-nacelle/config/v3 v3.0.0/go.mod h1:cj+WGluCHOR/5gup6dx3wunXsEGEbxmCiB6cYa9iNYQ=
 github.com/go-nacelle/log/v2 v2.0.1 h1:vOkiKz/pZannZIpH2yDV03hUKbtr6uLvrWklk8N6eR0=
 github.com/go-nacelle/log/v2 v2.0.1/go.mod h1:KpBIkm+Rc9qzdwUKQlhxbN0slXSKi/FhDWY5oiFVhY8=
-github.com/go-nacelle/process/v2 v2.0.1 h1:UEh+yr1Y+OdRU+LpwpyLHcXtdjRlZVIcRY+/m5GfuXY=
-github.com/go-nacelle/process/v2 v2.0.1/go.mod h1:rqzTvXR+gH0/f+7yBrxbVs8ZKL7AhYzNCxWvHIJF4Mk=
+github.com/go-nacelle/process/v2 v2.1.0 h1:T7cN5KUhhDJJ4qd38V7LmuQLKTvmUAK4ZXEHrL8MHeM=
+github.com/go-nacelle/process/v2 v2.1.0/go.mod h1:rqzTvXR+gH0/f+7yBrxbVs8ZKL7AhYzNCxWvHIJF4Mk=
 github.com/go-nacelle/service/v2 v2.0.1 h1:Pnxbqnpv2w0ntzYIMkRwCxoYbvvu35r9b4hTVrt2ZSE=
 github.com/go-nacelle/service/v2 v2.0.1/go.mod h1:o5K7mx7JaIxDbyfzFGH+JkRlTXUudjyx9Fx+AGHuk6I=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=


### PR DESCRIPTION
Update to process v2.1.0 and use the new `State.Errors` method to allow us to log process errors encountered by the `Bootstrapper`.